### PR TITLE
update readme for jdk8, add schema migration required for > 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Kaleido sample code for Corda
 
-Sample code for development components of a Corda App: contracts, flows and rpc-clients, based on JDK 11
+Sample code for development components of a Corda App: contracts, flows and rpc-clients, based on JDK 8
 
 © Copyright 2020 Kaleido
 
 ## Pre-reqs
-- JDK 11 (such as from [https://adoptopenjdk.net/](https://gradle.org/install/))
+- JDK 8 (such as from [https://adoptopenjdk.net/](https://gradle.org/install/))
 - gradle ([https://gradle.org/install/](https://gradle.org/install/))
 
 ## Set up the target Corda network

--- a/iou-contract/build.gradle
+++ b/iou-contract/build.gradle
@@ -13,10 +13,10 @@ plugins {
 
 dependencies {
     // these dependencies will be included in the contract jar
-    cordaRuntime 'net.corda:corda:4.4'
+    cordaRuntime 'net.corda:corda:4.8'
 
     // these dependencies will NOT be included in the contract jar
-    cordaCompile 'net.corda:corda-core:4.4'
+    cordaCompile 'net.corda:corda-core:4.8'
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:26.0-jre'
 
@@ -25,8 +25,8 @@ dependencies {
 }
 
 cordapp {
-    targetPlatformVersion 4
-    minimumPlatformVersion 4
+    targetPlatformVersion 10
+    minimumPlatformVersion 6
     contract {
         name "IoU Contract"
         vendor "Kaleido Open Source"

--- a/iou-contract/build.gradle
+++ b/iou-contract/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
 cordapp {
     targetPlatformVersion 10
-    minimumPlatformVersion 6
+    minimumPlatformVersion 10
     contract {
         name "IoU Contract"
         vendor "Kaleido Open Source"

--- a/iou-contract/src/main/java/io/kaleido/samples/schema/IOUSchemaV1.java
+++ b/iou-contract/src/main/java/io/kaleido/samples/schema/IOUSchemaV1.java
@@ -25,6 +25,10 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 import java.util.UUID;
 
+//4.6 changes
+import org.hibernate.annotations.Type;
+import javax.annotation.Nullable;
+
 /**
  * An IOUState schema.
  */
@@ -33,13 +37,19 @@ public class IOUSchemaV1 extends MappedSchema {
         super(IOUSchema.class, 1, ImmutableList.of(PersistentIOU.class));
     }
 
+    @Nullable
+    @Override
+    public String getMigrationResource() {
+        return "iou.changelog-master";
+    }
+
     @Entity
     @Table(name = "iou_states")
     public static class PersistentIOU extends PersistentState {
         @Column(name = "lender") private final String lender;
         @Column(name = "borrower") private final String borrower;
         @Column(name = "value") private final int value;
-        @Column(name = "linear_id") private final UUID linearId;
+        @Column(name = "linear_id") @Type (type = "uuid-char") private final UUID linearId;
 
 
         public PersistentIOU(String lender, String borrower, int value, UUID linearId) {

--- a/iou-flow/build.gradle
+++ b/iou-flow/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 cordapp {
     targetPlatformVersion 10
-    minimumPlatformVersion 6
+    minimumPlatformVersion 10
     workflow {
         name "IoU Flow"
         vendor "Kaleido Open Source"

--- a/iou-flow/build.gradle
+++ b/iou-flow/build.gradle
@@ -12,8 +12,8 @@ plugins {
 }
 
 cordapp {
-    targetPlatformVersion 4
-    minimumPlatformVersion 4
+    targetPlatformVersion 10
+    minimumPlatformVersion 6
     workflow {
         name "IoU Flow"
         vendor "Kaleido Open Source"
@@ -24,7 +24,7 @@ cordapp {
 
 dependencies {
     // these dependencies will NOT be included in the contract jar
-    cordaCompile 'net.corda:corda-core:4.4'
+    cordaCompile 'net.corda:corda-core:4.8'
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:26.0-jre'
 

--- a/iou-flow/src/main/resources/migration/iou.changelog-master.xml
+++ b/iou-flow/src/main/resources/migration/iou.changelog-master.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <include file="migration/iou.changelog-v1.xml"/>
+</databaseChangeLog>

--- a/iou-flow/src/main/resources/migration/iou.changelog-v1.xml
+++ b/iou-flow/src/main/resources/migration/iou.changelog-v1.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="R3.Corda" id="create_iou_state">
+        <createTable tableName="iou_states">
+            <column name="output_index" type="INT"/>
+            <column name="transaction_id" type="NVARCHAR(64)"/>
+            <column name="value" type="int"/>
+            <column name="lender" type="NVARCHAR(64)"/>
+            <column name="borrower" type="NVARCHAR(64)"/>
+            <column name="linear_id" type="NVARCHAR(64)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/rpc-client/build.gradle
+++ b/rpc-client/build.gradle
@@ -15,9 +15,9 @@ plugins {
 }
 
 dependencies {
-    compile 'net.corda:corda-core:4.4'
-    compile "net.corda:corda-rpc:4.4"
-    compile 'net.corda:corda:4.4'
+    compile 'net.corda:corda-core:4.8'
+    compile "net.corda:corda-rpc:4.8"
+    compile 'net.corda:corda:4.8'
     compile "org.slf4j:slf4j-simple:1.7.30"
     compile "info.picocli:picocli:4.2.0"
     compile "com.timgroup:java-statsd-client:3.0.1"


### PR DESCRIPTION
Changes to sample app to be able to run with corda 4.8 pulled from https://github.com/corda/samples-java/tree/4.8-samples/Basic/cordapp-example